### PR TITLE
fix: data race on closeStream

### DIFF
--- a/server.go
+++ b/server.go
@@ -998,7 +998,8 @@ func (sc *serverConn) wroteFrame(res frameWriteResult) {
 		case StreamError:
 			// st may be unknown if the RST_STREAM was generated to reject bad input.
 			if st, ok := sc.streams[v.StreamID]; ok {
-				sc.closeStream(st, v, false)
+				// if v.Code is ErrCodeNo, then we can release ctx safely
+				sc.closeStream(st, v, v.Code != ErrCodeNo)
 			}
 		case handlerPanicRST:
 			sc.closeStream(wr.stream, errHandlerPanicked, false)


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### What this PR does / why we need it (English/Chinese):

<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
修复在`closeStream`中出现的 data race
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
