### PR TITLE
fix: server will ignore last data when Read return n,EOF

### DIFF
--- a/factory/http2_test.go
+++ b/factory/http2_test.go
@@ -145,7 +145,9 @@ func getStream(data []byte) io.Reader {
 
 	go func() {
 		time.Sleep(100 * time.Millisecond)
-		writer.Write(data)
+		if len(data) != 0 {
+			writer.Write(data)
+		}
 		writer.Close()
 	}()
 
@@ -156,8 +158,10 @@ func getBadStream(data []byte) io.Reader {
 	reader, writer := io.Pipe()
 
 	go func() {
-		writer.Write(data)
 		time.Sleep(100 * time.Millisecond)
+		if len(data) != 0 {
+			writer.Write(data)
+		}
 		writer.CloseWithError(errors.New("test error"))
 	}()
 

--- a/server.go
+++ b/server.go
@@ -1836,14 +1836,14 @@ func (sc *serverConn) newWriterAndRequestNoBody(st *stream) (*responseWriter, er
 
 func writeResponseBody(rw *responseWriter, reqCtx *app.RequestContext) (err error) {
 	if reqCtx.Response.IsBodyStream() {
+		var n int
 		vbuf := utils.CopyBufPool.Get()
 		buf := vbuf.([]byte)
 		for {
-			var n int
 			n, err = reqCtx.Response.BodyStream().Read(buf)
 			if n == 0 {
 				if err == nil {
-					return errors.New("BUG: io.Reader returned 0, nil")
+					return errors.New("response bodyStream().Read(buf) returns 0, nil")
 				}
 				if err == io.EOF {
 					err = nil

--- a/server.go
+++ b/server.go
@@ -1834,26 +1834,29 @@ func (sc *serverConn) newWriterAndRequestNoBody(st *stream) (*responseWriter, er
 	return rw, nil
 }
 
-func writeResponseBody(rw *responseWriter, reqCtx *app.RequestContext) error {
+func writeResponseBody(rw *responseWriter, reqCtx *app.RequestContext) (err error) {
 	if reqCtx.Response.IsBodyStream() {
 		vbuf := utils.CopyBufPool.Get()
 		buf := vbuf.([]byte)
 		for {
-			n, err := reqCtx.Response.BodyStream().Read(buf)
-			if err == io.EOF {
+			var n int
+			n, err = reqCtx.Response.BodyStream().Read(buf)
+			if n == 0 {
+				if err == nil {
+					return errors.New("BUG: io.Reader returned 0, nil")
+				}
+				if err == io.EOF {
+					err = nil
+				}
 				break
 			}
-			if err != nil {
-				return err
-			}
-			_, err = rw.Write(buf[:n])
-			if err != nil {
-				return err
+			if _, err = rw.Write(buf[:n]); err != nil {
+				break
 			}
 		}
 		utils.CopyBufPool.Put(vbuf)
 
-		return nil
+		return err
 	} else {
 		// reqCtx.Response.Body can be no error
 		// will split at FrameWriteRequest's Consume function

--- a/server_test.go
+++ b/server_test.go
@@ -202,6 +202,7 @@ func newHertzServerTester(t testing.TB, handler app.HandlerFunc, opts ...interfa
 	}
 	st.hpackEnc = hpack.NewEncoder(&st.headerBuf)
 	st.hpackDec = hpack.NewDecoder(initialHeaderTableSize, st.onHeaderField)
+	st.addLogFilter("Transport readFrame error")
 
 	testHookGetServerConn = func(v *serverConn) {
 		st.scMu.Lock()
@@ -228,6 +229,7 @@ func newHertzServerTester(t testing.TB, handler app.HandlerFunc, opts ...interfa
 			st.fr.logWrites = true
 		}
 	}
+
 	return st
 }
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### What this PR does / why we need it (English/Chinese):
当 `bodyStream.Read` 返回 n, EOF 的时候，server 会直接丢弃掉这次 Read 的数据
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
