### PR TITLE
fix: skip write body when status not allowed

### DIFF
--- a/server.go
+++ b/server.go
@@ -1854,6 +1854,9 @@ func (sc *serverConn) newWriterAndRequestNoBody(st *stream) (*responseWriter, er
 }
 
 func writeResponseBody(rw *responseWriter, reqCtx *app.RequestContext) (err error) {
+	if !bodyAllowedForStatus(reqCtx.Response.StatusCode()) {
+		return nil
+	}
 	if reqCtx.Response.IsBodyStream() {
 		var n int
 		vbuf := utils.CopyBufPool.Get()


### PR DESCRIPTION
#### What type of PR is this?

fix

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (English/Chinese):

en: don't write body when status not allowed.  According to the RFC definition https://www.rfc-editor.org/rfc/rfc9110.html#name-204-no-content, 204 and 304 response is terminated by the end of the header section; it cannot contain content or trailers.
zh: 状态码不允许存在body的时候不写入body。根据rfc定义，204、304还有其他几个状态码，不能设置响应body，这里跳过写入body。
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->

#### Which issue(s) this PR fixes:


<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/cloudwego/hertz/issues/788

