### PR TITLE
fix: 304 status code return error

### DIFF
--- a/response_writer.go
+++ b/response_writer.go
@@ -299,12 +299,7 @@ func (w *responseWriter) write(lenData int, dataB []byte, dataS string) (n int, 
 	if rws == nil {
 		panic("Write called after Handler finished")
 	}
-	if !rws.wroteHeader {
-		w.WriteHeader(200)
-	}
-	if !bodyAllowedForStatus(rws.status) {
-		return 0, http.ErrBodyNotAllowed
-	}
+
 	rws.wroteBytes += int64(len(dataB)) + int64(len(dataS)) // only one can be set
 	if rws.sentContentLen != 0 && rws.wroteBytes > rws.sentContentLen {
 		// TODO: send a RST_STREAM


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### What this PR does / why we need it (English/Chinese):
en: The error occurred with the 304 status code. The 304 status code is not considered an error per se, as it indicates that the requested resource has not been modified since the last request. However, in HTTP/2, the 304 status code is treated as an error in terms of handling, where it does not allow for a response body to be returned.
zh: 304 状态码返回了 error。304 状态码只是不允许返回 body，不是请求错误，但是在 h2 当中把 304 状态码当作错误处理了。
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
