### PR TITLE
Fix stateHalfClosedRemote to stateHalfClosedLocal in wroteFrame function

### DIFF
--- a/server.go
+++ b/server.go
@@ -989,7 +989,7 @@ func (sc *serverConn) wroteFrame(res frameWriteResult) {
 			// RST_STREAM with an error code of NO_ERROR after sending
 			// a complete response.
 			sc.resetStream(streamError(st.id, ErrCodeNo))
-		case stateHalfClosedRemote:
+		case stateHalfClosedLocal:
 			sc.closeStream(st, errHandlerComplete, false)
 		}
 	} else {


### PR DESCRIPTION
#### What type of PR is this?
When the local side of the server stream is in a closed state, the stream should be closed. The previous implementation caused the handler to continue executing even after closing the stream.
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (English/Chinese):

<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
